### PR TITLE
Add string_force_source_encoding configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This way you can avoid Encoding::InvalidByteSequenceError when tag contains inva
 ```ruby
 ID3Tag.configuration do |c|
   c.string_encode_options = { :invalid => :replace, :undef => :replace }
+  c.string_source_encoding = Encoding::UTF_16LE
 end
 ```
 

--- a/lib/id3tag/configuration.rb
+++ b/lib/id3tag/configuration.rb
@@ -2,8 +2,10 @@ module ID3Tag
   class Configuration
     def initialize
       @string_encode_options = {}
+      @string_source_encoding = nil
     end
 
     attr_accessor :string_encode_options
+    attr_accessor :string_source_encoding
   end
 end

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -25,6 +25,7 @@ module  ID3Tag
         end
 
         def source_encoding
+          return ID3Tag.configuration.string_source_encoding if ID3Tag.configuration.string_source_encoding
           ENCODING_MAP.fetch(get_encoding_byte) { raise UnsupportedTextEncoding }.to_s
         end
 

--- a/spec/lib/id3tag/frames/v2/text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/text_frame_spec.rb
@@ -59,18 +59,43 @@ describe ID3Tag::Frames::V2::TextFrame do
 
     context "when UTF-16 and missing BOM" do
       let(:target_encoding) { Encoding::UTF_8 }
-      let(:raw_content) { "\x01\x00\x00a\x00b\x00c" }
+      let(:raw_content) { "\x01a\x00b\x00c\x00" }
       it "raises error Encoding::InvalidByteSequenceError" do
         expect { subject }.to raise_error(Encoding::InvalidByteSequenceError)
       end
       context "when using global encode options" do
         before(:each) do
           ID3Tag.configuration do |c|
-            c.string_encode_options = { :invalid => :replace, :undef => :replace }
+            c.string_encode_options = { :invalid => :replace, :undef => :replace, :replace => "R" }
+          end
+        end
+        after(:each) do
+          ID3Tag.configuration do |c|
+            c.string_encode_options = {}
+            c.string_source_encoding = nil
           end
         end
         it "does not raise error" do
           expect { subject }.not_to raise_error
+          should == "RRR"
+        end
+      end
+
+      context "when using global source encoding" do
+        before(:each) do
+          ID3Tag.configuration do |c|
+            c.string_source_encoding = Encoding::UTF_16LE
+          end
+        end
+        after(:each) do
+          ID3Tag.configuration do |c|
+            c.string_encode_options = {}
+            c.string_source_encoding = nil
+          end
+        end
+        it "does not raise error" do
+          expect { subject }.not_to raise_error
+          should == "abc"
         end
       end
     end


### PR DESCRIPTION
Useful for reading broken tags, e.g. frames with UTF-16
encoding but no BOM.

Added string_source_encoding spec.
Make sure to reset global configuration in specs.
Reworked string_encoding_options test to check for replaced
characters.
