### PR TITLE
Always return a string for `StringUtil#cut_at_null_byte`

### DIFF
--- a/lib/id3tag/string_util.rb
+++ b/lib/id3tag/string_util.rb
@@ -20,7 +20,7 @@ module ID3Tag
     end
 
     def self.cut_at_null_byte(string)
-      string.split(NULL_BYTE, 2).first
+      string.split(NULL_BYTE, 2).first.to_s
     end
 
     def self.split_by_null_byte(string)

--- a/spec/lib/id3tag/string_util_spec.rb
+++ b/spec/lib/id3tag/string_util_spec.rb
@@ -47,6 +47,21 @@ describe ID3Tag::StringUtil do
     end
   end
 
+  describe "cut_at_null_byte" do
+    let(:input) { }
+    subject { described_class.cut_at_null_byte(input) }
+
+    context 'when content is empty' do
+      let(:input) { '' }
+      it { is_expected.to eq('') }
+    end
+
+    context 'when content is present' do
+      let(:input) { "a\u0000b" }
+      it { is_expected.to eq('a') }
+    end
+  end
+
   describe "split_by_null_byte" do
     let(:input) { }
     subject { described_class.split_by_null_byte(input) }


### PR DESCRIPTION
I came across this strange behavior after reading the following [open issue](https://github.com/WeTransfer/format_parser/issues/118). Here's the stack trace with some insight:
```bash
1) FormatParser::MP3Parser decodes and estimates duration for a CBR MP3
     Failure/Error: value = tag.public_send(k)
     
     NoMethodError:
       undefined method `gsub' for nil:NilClass
     # /Users/code/libs/id3tag/lib/id3tag/frames/v2/genre_frame/genre_parser_pre_24.rb:25:in `just_genres'
     # /Users/code/libs/id3tag/lib/id3tag/frames/v2/genre_frame/genre_parser_pre_24.rb:12:in `genres'
     # /Users/code/libs/id3tag/lib/id3tag/frames/v2/genre_frame.rb:23:in `get_genres'
     # /Users/code/libs/id3tag/lib/id3tag/frames/v2/genre_frame.rb:8:in `genres'
```
### The symptom:
The [`#initialize`](https://github.com/krists/id3tag/blob/master/lib/id3tag/frames/v2/genre_frame/genre_parser.rb#L10)  method of the class `ID3Tag::Frames::V2::GenreFrame::GenreParser` expects to get a string as a parameter but it can be invoked with `nil` instead. 

### Potential problem:
This scenario can happen due to the fact that `StringUtil#cut_at_null_byte` can return a value different than `String`.  You can find one instance of the issue in [`D3Tag::Frames::V2::TextFrame`](https://github.com/krists/id3tag/blob/master/lib/id3tag/frames/v2/text_frame.rb#L14)

From the point of view of the `StringUtil` interface, I expect that `cut_at_null_byte` would cut the string until the first `null_byte` and return the first piece of the string. That happens in most of the cases but the edge case of "empty string" is still not covered.

### Proposed solution:
In order to fix the issue and the symptoms, we just need to make sure `#cut_at_null_byte` returns always a `String`.

I've added some `specs` to the method `StringUtil#cut_at_null_byte` too. 

Let me know if you have any questions or comments. I would be very happy to help :)
Thanks!