### PR TITLE
Ruby 2.7 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ cache: bundler
 before_install:
   - gem install bundler
 rvm:
-  - ruby-head
-  - jruby-head
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
-  - jruby-9.1.13.0
-matrix:
-  allow_failures:
-    - rvm: jruby-head
-    - rvm: ruby-head
+  - 2.7.0-preview3
+  - 2.6
+  - 2.5
+  - 2.4
+  - jruby

--- a/lib/id3tag/encoding_util.rb
+++ b/lib/id3tag/encoding_util.rb
@@ -27,7 +27,7 @@ module ID3Tag
     end
 
     def self.encode(text, source_encoding)
-      text.encode(DESTINATION_ENCODING, source_encoding, ID3Tag.configuration.string_encode_options)
+      text.encode(DESTINATION_ENCODING, source_encoding, **ID3Tag.configuration.string_encode_options)
     end
   end
 end

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -21,7 +21,7 @@ module  ID3Tag
         private
 
         def encoded_content
-          content_without_encoding_byte.encode(destination_encoding, source_encoding, ID3Tag.configuration.string_encode_options)
+          content_without_encoding_byte.encode(destination_encoding, source_encoding, **ID3Tag.configuration.string_encode_options)
         end
 
         def source_encoding


### PR DESCRIPTION
Remove "warning: The last argument is used as keyword parameters"