### PR TITLE
Add config.fallback_source_encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /pkg/
 /rdoc/
 /coverage/
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -67,14 +67,20 @@ ID3Tag.configuration do |c|
 
   # This way you can avoid Encoding::InvalidByteSequenceError when tag contains invalid data.
   # Currently only for String#encode which is used in TextFrames.
-  # default: {} 
+  # default: {}
   c.string_encode_options = { :invalid => :replace, :undef => :replace }
-  
+
   # You might want to set v2.x tag read limit in bytes to avoid reading too much data into memory
   # v2 tags will be extracted until end of tag or limit is reached.
-  # default: 0 (There are no limit) 
+  # default: 0 (There are no limit)
   c.v2_tag_read_limit = 1048576 # 1 megabyte
-  
+
+  # In some situations, it's not possible to recognize what is the encoding of a
+  # text frame. The default behavior is to raise UnsupportedTextEncoding, but
+  # it's possible to set a fallback to avoid it.
+  # default: nil
+  c.fallback_source_encoding = Encoding::UTF_8
+
 end
 
 ID3Tag.configuration.v2_tag_read_limit # 1048576
@@ -91,7 +97,7 @@ ID3Tag.local_configuration do
   ID3Tag.configuration.v2_tag_read_limit # 1024
   ID3Tag.configuration.v2_tag_read_limit = 9999
   # ...
-  ID3Tag.configuration.v2_tag_read_limit # 9999 
+  ID3Tag.configuration.v2_tag_read_limit # 9999
 end
 
 ID3Tag.configuration.v2_tag_read_limit # 1024

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ID3Tag.configuration do |c|
   # text frame. The default behavior is to raise UnsupportedTextEncoding, but
   # it's possible to set a fallback to avoid it.
   # default: nil
-  c.fallback_source_encoding = Encoding::UTF_8
+  c.source_encoding_fallback = Encoding::UTF_8
 
 end
 

--- a/lib/id3tag/configuration_struct.rb
+++ b/lib/id3tag/configuration_struct.rb
@@ -3,11 +3,11 @@ module ID3Tag
     def initialize
       @string_encode_options = {}
       @v2_tag_read_limit = 0
-      @fallback_source_encoding = nil
+      @source_encoding_fallback = nil
     end
 
     attr_accessor :string_encode_options
     attr_accessor :v2_tag_read_limit
-    attr_accessor :fallback_source_encoding
+    attr_accessor :source_encoding_fallback
   end
 end

--- a/lib/id3tag/configuration_struct.rb
+++ b/lib/id3tag/configuration_struct.rb
@@ -3,9 +3,11 @@ module ID3Tag
     def initialize
       @string_encode_options = {}
       @v2_tag_read_limit = 0
+      @fallback_source_encoding = nil
     end
 
     attr_accessor :string_encode_options
     attr_accessor :v2_tag_read_limit
+    attr_accessor :fallback_source_encoding
   end
 end

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -25,7 +25,9 @@ module  ID3Tag
         end
 
         def source_encoding
-          ENCODING_MAP.fetch(get_encoding_byte) { raise UnsupportedTextEncoding }.to_s
+          ENCODING_MAP.fetch(get_encoding_byte) do
+            ID3Tag.configuration.fallback_source_encoding || raise(UnsupportedTextEncoding)
+          end.to_s
         end
 
         def destination_encoding

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -26,7 +26,7 @@ module  ID3Tag
 
         def source_encoding
           ENCODING_MAP.fetch(get_encoding_byte) do
-            ID3Tag.configuration.fallback_source_encoding || raise(UnsupportedTextEncoding)
+            ID3Tag.configuration.source_encoding_fallback || raise(UnsupportedTextEncoding)
           end.to_s
         end
 

--- a/spec/lib/id3tag/frames/v2/text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/text_frame_spec.rb
@@ -28,14 +28,14 @@ describe ID3Tag::Frames::V2::TextFrame do
     end
 
     context "when encoding byte is not present" do
-      context "when config.fallback_source_encoding is not set" do
+      context "when config.source_encoding_fallback is not set" do
         let(:encoding_byte) { "" }
         it { expect { subject }.to raise_error(ID3Tag::Frames::V2::TextFrame::UnsupportedTextEncoding) }
       end
 
-      context "when config.fallback_source_encoding is set" do
+      context "when config.source_encoding_fallback is set" do
         let(:encoding_byte) { "" }
-        before { ID3Tag.configuration.fallback_source_encoding = Encoding::UTF_8 }
+        before { ID3Tag.configuration.source_encoding_fallback = Encoding::UTF_8 }
         it { is_expected.to eq('lāzšķūņrūķīši') }
       end
     end

--- a/spec/lib/id3tag/frames/v2/text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/text_frame_spec.rb
@@ -28,8 +28,16 @@ describe ID3Tag::Frames::V2::TextFrame do
     end
 
     context "when encoding byte is not present" do
-      let(:encoding_byte) { "" }
-      it { expect { subject }.to raise_error(ID3Tag::Frames::V2::TextFrame::UnsupportedTextEncoding) }
+      context "when config.fallback_source_encoding is not set" do
+        let(:encoding_byte) { "" }
+        it { expect { subject }.to raise_error(ID3Tag::Frames::V2::TextFrame::UnsupportedTextEncoding) }
+      end
+
+      context "when config.fallback_source_encoding is set" do
+        let(:encoding_byte) { "" }
+        before { ID3Tag.configuration.fallback_source_encoding = Encoding::UTF_8 }
+        it { is_expected.to eq('lāzšķūņrūķīši') }
+      end
     end
 
     context "when encoding is ISO08859_1" do


### PR DESCRIPTION
related to https://github.com/WeTransfer/format_parser/pull/161#issuecomment-684422012

Add `config.fallback_source_encoding` to avoid raising `UnsupportedTextEncoding`