### PR TITLE
Using EncodingUtil.encode everywhere

### DIFF
--- a/lib/id3tag/frames/v1/comments_frame.rb
+++ b/lib/id3tag/frames/v1/comments_frame.rb
@@ -15,7 +15,7 @@ module ID3Tag
         end
 
         def content
-          @content.encode(destination_encoding, source_encoding)
+          EncodingUtil.encode(@content, source_encoding)
         end
       end
     end

--- a/lib/id3tag/frames/v1/text_frame.rb
+++ b/lib/id3tag/frames/v1/text_frame.rb
@@ -9,14 +9,10 @@ module ID3Tag
         end
 
         def content
-          @content.encode(destination_encoding, source_encoding)
+          EncodingUtil.encode(@content, source_encoding)
         end
 
         private
-
-        def destination_encoding
-          Encoding::UTF_8
-        end
 
         def source_encoding
           Encoding::ISO8859_1

--- a/lib/id3tag/frames/v2/comments_frame.rb
+++ b/lib/id3tag/frames/v2/comments_frame.rb
@@ -32,7 +32,7 @@ module  ID3Tag
         end
 
         def encoded_content
-          content_without_encoding_byte_and_language.encode(destination_encoding, source_encoding)
+          EncodingUtil.encode(content_without_encoding_byte_and_language, source_encoding)
         end
 
         def content_without_encoding_byte_and_language

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -21,7 +21,7 @@ module  ID3Tag
         private
 
         def encoded_content
-          content_without_encoding_byte.encode(destination_encoding, source_encoding, **ID3Tag.configuration.string_encode_options)
+          EncodingUtil.encode(content_without_encoding_byte, source_encoding)
         end
 
         def source_encoding

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -30,10 +30,6 @@ module  ID3Tag
           end.to_s
         end
 
-        def destination_encoding
-          Encoding::UTF_8.to_s
-        end
-
         def get_encoding_byte
           raw_content_io.rewind
           raw_content_io.getbyte


### PR DESCRIPTION
Some places were calling `String#encode` without using `configuration.string_encode_options`.

For that reason, it could raise errors like that:
```
3: from /Users/fabioperrella/projects/id3tag/lib/id3tag/frames/v2/comments_frame.rb:17:in `text'
2: from /Users/fabioperrella/projects/id3tag/lib/id3tag/frames/v2/comments_frame.rb:31:in `parts'
1: from /Users/fabioperrella/projects/id3tag/lib/id3tag/frames/v2/comments_frame.rb:35:in `encoded_content'
/Users/fabioperrella/projects/id3tag/lib/id3tag/frames/v2/comments_frame.rb:35:in `encode': "\x00\x00" on UTF-16 (Encoding::InvalidByteSequenceError)
```

So I changed all of them to use `EncodingUtil.encode` which encapsulates that.

I didn't manage to create a test to reproduce the error that I mentioned. I got a mp3 file from production and I don't have the customer permission to share it.

After these modifications that I made, I tested with the same file again and it worked!