### PR TITLE
Add part of a set frame support

### DIFF
--- a/lib/id3tag/frame_id_advisor.rb
+++ b/lib/id3tag/frame_id_advisor.rb
@@ -20,6 +20,7 @@ module ID3Tag
         :comments => :COM,
         :genre => :TCO,
         :track_nr => :TRK,
+        :disc => :TPA,
         :unsychronized_transcription => :ULT,
         :image => :PIC
       },
@@ -31,6 +32,7 @@ module ID3Tag
         :comments => :COMM,
         :genre => :TCON,
         :track_nr => :TRCK,
+        :disc => :TPOS,
         :unsychronized_transcription => :USLT,
         :image => :APIC
       },
@@ -42,6 +44,7 @@ module ID3Tag
         :comments => :COMM,
         :genre => :TCON,
         :track_nr => :TRCK,
+        :disc => :TPOS,
         :unsychronized_transcription => :USLT,
         :image => :APIC
       }

--- a/lib/id3tag/frame_id_advisor.rb
+++ b/lib/id3tag/frame_id_advisor.rb
@@ -20,7 +20,7 @@ module ID3Tag
         :comments => :COM,
         :genre => :TCO,
         :track_nr => :TRK,
-        :disc => :TPA,
+        :disc_nr => :TPA,
         :unsychronized_transcription => :ULT,
         :image => :PIC
       },
@@ -32,7 +32,7 @@ module ID3Tag
         :comments => :COMM,
         :genre => :TCON,
         :track_nr => :TRCK,
-        :disc => :TPOS,
+        :disc_nr => :TPOS,
         :unsychronized_transcription => :USLT,
         :image => :APIC
       },
@@ -44,7 +44,7 @@ module ID3Tag
         :comments => :COMM,
         :genre => :TCON,
         :track_nr => :TRCK,
-        :disc => :TPOS,
+        :disc_nr => :TPOS,
         :unsychronized_transcription => :USLT,
         :image => :APIC
       }


### PR DESCRIPTION
Adds support for looking up "part of a set" (`TPA`/`TPOS`) as `disc`.

Note that this PR doesn't include a spec because I wasn't sure where/how you'd prefer it to be tested. The easiest thing would just be to drop another MP3 in `spec/fixtures` and add a standalone feature spec, but that seemed like overkill. (Also I don't think I have any tools handy that will write v2.2 tags.)