### PR TITLE
Conform to the unsynchronization specification

### DIFF
--- a/lib/id3tag/unsynchronization.rb
+++ b/lib/id3tag/unsynchronization.rb
@@ -10,7 +10,7 @@ module ID3Tag
         current_byte = input_bytes.next
         output_bytes << current_byte
         next_byte = input_bytes.peek
-        if (current_byte == 255) && (next_byte > 224)
+        if (current_byte == 255) && ((next_byte >= 224) || (next_byte == 0))
           output_bytes << 0
         end
       end
@@ -20,8 +20,8 @@ module ID3Tag
       prev_byte = nil
       loop do
         current_byte = input_bytes.next
-        next_byte = input_bytes.peek rescue 0
-        unless (prev_byte == 255) && (current_byte == 0) && (next_byte > 224)
+        next_byte = input_bytes.peek rescue nil
+        unless (prev_byte == 255) && (current_byte == 0) && (next_byte != nil) && ((next_byte >= 224) || (next_byte == 0))
           output_bytes << current_byte
         end
         prev_byte = current_byte

--- a/spec/lib/id3tag/string_util_spec.rb
+++ b/spec/lib/id3tag/string_util_spec.rb
@@ -24,12 +24,20 @@ describe ID3Tag::StringUtil do
     subject { described_class.do_unsynchronization(input) }
 
     context "when a false synchronization is present" do
-      let(:input) { "\xFF\xEE" }
-      it { is_expected.to eq("\xFF\x00\xEE") }
+      let(:input) { "\xFF\xE0" }
+      it { is_expected.to eq("\xFF\x00\xE0") }
+    end
+    context "when an unsynchronization marker is present" do
+      let(:input) { "\xFF\x00" }
+      it { is_expected.to eq("\xFF\x00\x00") }
+    end
+    context "when \\xFF is at the end of the data" do
+      let(:input) { "\xFF" }
+      it { is_expected.to eq("\xFF") }
     end
     context "when a false synchronization is not present" do
-      let(:input) { "\xEE\xEE" }
-      it { is_expected.to eq("\xEE\xEE") }
+      let(:input) { "\xFF\x01" }
+      it { is_expected.to eq("\xFF\x01") }
     end
   end
 
@@ -38,12 +46,24 @@ describe ID3Tag::StringUtil do
     subject { described_class.undo_unsynchronization(input) }
 
     context "when unsynchronization in present" do
-      let(:input) { "\xFF\x00\xEE\xEE" }
-      it { is_expected.to eq("\xFF\xEE\xEE") }
+      let(:input) { "\xFF\x00\xE0" }
+      it { is_expected.to eq("\xFF\xE0") }
+    end
+    context "when false unsynchronization in present" do
+      let(:input) { "\xFF\x00" }
+      it { is_expected.to eq("\xFF\x00") }
+    end
+    context "when an unsynchronization marker is present" do
+      let(:input) { "\xFF\x00\x00" }
+      it { is_expected.to eq("\xFF\x00") }
+    end
+    context "when \\xFF is at the end of the data" do
+      let(:input) { "\xFF" }
+      it { is_expected.to eq("\xFF") }
     end
     context "when unsynchronization in not present" do
-      let(:input) { "\xEE\xEE" }
-      it { is_expected.to eq("\xEE\xEE") }
+      let(:input) { "\xFF\x01" }
+      it { is_expected.to eq("\xFF\x01") }
     end
   end
 


### PR DESCRIPTION
The old code mishandled the \xFF\xE0 and \xFF\x00 sequences in the data to be unsynchronized as well as their counterparts in the data to be de-unsynchronized.