### PR TITLE
Support reading multiple text strings from single tag

### DIFF
--- a/lib/id3tag/frames/v2/comments_frame.rb
+++ b/lib/id3tag/frames/v2/comments_frame.rb
@@ -21,6 +21,14 @@ module  ID3Tag
           text
         end
 
+        def texts
+          @texts ||= StringUtil.split_by_null_bytes(parts.last)
+        end
+
+        def contents
+          texts
+        end
+
         def inspectable_content
           content
         end

--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -14,6 +14,10 @@ module  ID3Tag
           @content ||= StringUtil.cut_at_null_byte(encoded_content)
         end
 
+        def contents
+          @contents ||= StringUtil.split_by_null_bytes(encoded_content)
+        end
+
         def inspectable_content
           content
         end

--- a/lib/id3tag/frames/v2/user_text_frame.rb
+++ b/lib/id3tag/frames/v2/user_text_frame.rb
@@ -7,6 +7,10 @@ module  ID3Tag
           StringUtil.cut_at_null_byte(content_parts.last)
         end
 
+        def contents
+          StringUtil.split_by_null_bytes(content_parts.last)
+        end
+
         def description
           content_parts.first
         end

--- a/lib/id3tag/string_util.rb
+++ b/lib/id3tag/string_util.rb
@@ -40,5 +40,9 @@ module ID3Tag
       end
       [before.pack(UTF_8_DIRECTIVE), after.pack(UTF_8_DIRECTIVE)]
     end
+
+    def self.split_by_null_bytes(string)
+      string.split(NULL_BYTE)
+    end
   end
 end

--- a/spec/lib/id3tag/frames/v2/comments_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/comments_frame_spec.rb
@@ -27,6 +27,19 @@ describe ID3Tag::Frames::V2::CommentsFrame do
     it { is_expected.to eq('Glāzšķūņrūķīši') }
   end
 
+  describe '#contents' do
+    subject { frame.contents }
+
+    context "when single value is present" do
+      it { is_expected.to eq(["Glāzšķūņrūķīši"]) }
+    end
+
+    context "when multiple values are present" do
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq(["Glāzšķūņrūķīši", "Glāzšķūņrūķīši"]) }
+    end
+  end
+
   describe '#language' do
     subject { frame.language }
     it { is_expected.to eq('lav') }

--- a/spec/lib/id3tag/frames/v2/text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/text_frame_spec.rb
@@ -89,6 +89,19 @@ describe ID3Tag::Frames::V2::TextFrame do
     end
   end
 
+  describe '#contents' do
+    subject { frame.contents }
+
+    context "when single value is present" do
+      it { is_expected.to eq(["Glāzšķūņrūķīši"]) }
+    end
+
+    context "when multiple values are present" do
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq(["Glāzšķūņrūķīši", "Glāzšķūņrūķīši"]) }
+    end
+  end
+
   describe '#inspect' do
     it 'should be pretty inspectable' do
       expect(frame.inspect).to eq('<ID3Tag::Frames::V2::TextFrame artist: Glāzšķūņrūķīši>')

--- a/spec/lib/id3tag/frames/v2/user_text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/user_text_frame_spec.rb
@@ -22,6 +22,19 @@ describe ID3Tag::Frames::V2::UserTextFrame do
     it { is_expected.to eq('Glāzšķūņrūķīši') }
   end
 
+  describe '#contents' do
+    subject { super().contents }
+
+    context "when single value is present" do
+      it { is_expected.to eq(["Glāzšķūņrūķīši"]) }
+    end
+
+    context "when multiple values are present" do
+      let(:text) { "SUPER_FRAME\x00Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq(["Glāzšķūņrūķīši", "Glāzšķūņrūķīši"]) }
+    end
+  end
+
   describe '#description' do
     subject { super().description }
     it { is_expected.to eq('SUPER_FRAME') }

--- a/spec/lib/id3tag/string_util_spec.rb
+++ b/spec/lib/id3tag/string_util_spec.rb
@@ -73,9 +73,26 @@ describe ID3Tag::StringUtil do
       let(:input) { "a\u0000\u0000b" }
       it { is_expected.to eq(["a", "\u0000b"]) }
     end
-    context "when content have multiple null bytes" do
+    context "when content have no null bytes" do
       let(:input) { "abc" }
       it { is_expected.to eq(["abc", ""]) }
+    end
+  end
+
+  describe "split_by_null_bytes" do
+    let(:input) { }
+    subject { described_class.split_by_null_bytes(input) }
+    context "when content have only 1 null byte" do
+      let(:input) { "a\u0000b" }
+      it { is_expected.to eq(["a", "b"]) }
+    end
+    context "when content have multiple null bytes" do
+      let(:input) { "a\u0000\u0000b" }
+      it { is_expected.to eq(["a", "", "b"]) }
+    end
+    context "when content have no null bytes" do
+      let(:input) { "abc" }
+      it { is_expected.to eq(["abc"]) }
     end
   end
 end


### PR DESCRIPTION
Comment, text and user text frames support storing multiple values in a single tag. Add a method (#contents) for returning these strings as an array.