### PR TITLE
Support reading multiple text strings from single tag v2

### DIFF
--- a/lib/id3tag/frames/v2/text_frame.rb
+++ b/lib/id3tag/frames/v2/text_frame.rb
@@ -11,7 +11,15 @@ module  ID3Tag
         }
 
         def content
-          @content ||= StringUtil.cut_at_null_byte(encoded_content)
+          @content ||= if @major_version_number >= 4
+            StringUtil.chomp_null_byte(encoded_content)
+          else
+            StringUtil.cut_at_null_byte(encoded_content)
+          end
+        end
+
+        def contents
+          @contents ||= StringUtil.split_by_null_bytes(content)
         end
 
         def inspectable_content

--- a/lib/id3tag/string_util.rb
+++ b/lib/id3tag/string_util.rb
@@ -40,5 +40,13 @@ module ID3Tag
       end
       [before.pack(UTF_8_DIRECTIVE), after.pack(UTF_8_DIRECTIVE)]
     end
+
+    def self.split_by_null_bytes(string)
+      string.split(NULL_BYTE)
+    end
+
+    def self.chomp_null_byte(string)
+      string.chomp(NULL_BYTE)
+    end
   end
 end

--- a/spec/lib/id3tag/frames/v2/text_frame_spec.rb
+++ b/spec/lib/id3tag/frames/v2/text_frame_spec.rb
@@ -87,6 +87,36 @@ describe ID3Tag::Frames::V2::TextFrame do
         end
       end
     end
+
+    context "when multiple values are present" do
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq("Glāzšķūņrūķīši\x00Glāzšķūņrūķīši") }
+    end
+
+    context "when multiple values are present in older tag" do
+      let(:major_version_number) { 3 }
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq("Glāzšķūņrūķīši") }
+    end
+  end
+
+  describe '#contents' do
+    subject { frame.contents }
+
+    context "when single value is present" do
+      it { is_expected.to eq(["Glāzšķūņrūķīši"]) }
+    end
+
+    context "when multiple values are present" do
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq(["Glāzšķūņrūķīši", "Glāzšķūņrūķīši"]) }
+    end
+
+    context "when multiple values are present is older tag" do
+      let(:major_version_number) { 3 }
+      let(:text) { "Glāzšķūņrūķīši\x00Glāzšķūņrūķīši" }
+      it { is_expected.to eq(["Glāzšķūņrūķīši"]) }
+    end
   end
 
   describe '#inspect' do

--- a/spec/lib/id3tag/string_util_spec.rb
+++ b/spec/lib/id3tag/string_util_spec.rb
@@ -73,9 +73,39 @@ describe ID3Tag::StringUtil do
       let(:input) { "a\u0000\u0000b" }
       it { is_expected.to eq(["a", "\u0000b"]) }
     end
-    context "when content have multiple null bytes" do
+    context "when content have no null bytes" do
       let(:input) { "abc" }
       it { is_expected.to eq(["abc", ""]) }
+    end
+  end
+
+  describe "split_by_null_bytes" do
+    let(:input) { }
+    subject { described_class.split_by_null_bytes(input) }
+    context "when content have only 1 null byte" do
+      let(:input) { "a\u0000b" }
+      it { is_expected.to eq(["a", "b"]) }
+    end
+    context "when content have multiple null bytes" do
+      let(:input) { "a\u0000\u0000b" }
+      it { is_expected.to eq(["a", "", "b"]) }
+    end
+    context "when content have no null bytes" do
+      let(:input) { "abc" }
+      it { is_expected.to eq(["abc"]) }
+    end
+  end
+
+  describe "chomp_null_byte" do
+    let(:input) { }
+    subject { described_class.chomp_null_byte(input) }
+    context "when content has trailing null byte" do
+      let(:input) { "a\u0000b\u0000" }
+      it { is_expected.to eq("a\u0000b") }
+    end
+    context "when content have no trailing null bytes" do
+      let(:input) { "a\u0000b" }
+      it { is_expected.to eq("a\u0000b") }
     end
   end
 end


### PR DESCRIPTION
Since v2.4 text frames support storing multiple strings in a single
frame. Modify the #content method to return the null separated strings
when appropriate. Add a method (#contents) for returning these strings
as an array.